### PR TITLE
Add Fall 2025 apparel & order support

### DIFF
--- a/frontend/src/pages/Shop/sections/Apparel.js
+++ b/frontend/src/pages/Shop/sections/Apparel.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState} from 'react';
 import { Link } from 'react-router-dom';
+import InstagramPost from "../../../components/InstaPosts/InstagramPost"; 
 
 import './Apparel.css';
 import Image1 from '../images/image1.png';
@@ -52,7 +53,27 @@ const Apparel = () => {
     <section className="apparel-section" id="apparel">
       <h1 className='shop-title title'>Apparel</h1>
 
-      <h2>Spring 2025</h2>
+      <h2>Fall 2025</h2> {/* new update for fall 2025, instagram post for a hoodie */}
+      <div className="apparel-blocks">
+        <div className="apparel-item">
+          <figure className="event-figure">
+            <InstagramPost url="https://www.instagram.com/p/DRQ3FxNDVSh/?igsh=emFjaWJnMTY5ams3" />
+            </figure>
+            <div style={{ display: 'flex', gap: '15px', justifyContent: 'center', marginTop: '15px' }}>
+              <Link className="order-button" to="/order?apparel=fall25shirt">
+                Order Shirt
+              </Link>
+              <Link className="order-button" to="/order?apparel=fall25hoodie">
+                Order Hoodie
+              </Link>
+              <Link className="order-button" to="/order?apparel=fall25both">
+                Order Both
+              </Link>
+            </div>
+          </div>
+      </div>
+
+      <h2 style={{ marginTop: '60px' }}>Spring 2025</h2>
       <div className="apparel-blocks">
         <div className="apparel-item">
           <img src={SP25ShirtFront} alt="Spring 2025 Shirt Front" className="sp25-apparel-cover"/>

--- a/frontend/src/pages/Shop/sections/order-pages/OrderPage.js
+++ b/frontend/src/pages/Shop/sections/order-pages/OrderPage.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import InstagramPost from "../../../../components/InstaPosts/InstagramPost";
+
 import './OrderPage.css'
 
 import {SP25ShirtFront, SP25ShirtBack, SP25HoodieFront, SP25HoodieBack,
@@ -8,6 +10,24 @@ DTJShirtFront, DTJShirtBack, DTJCrewFront, DTJCrewBack, DTJSweats}
 from '../Apparel.js';
 
 const apparelData = {
+    'fall25shirt' : {
+        name: 'Fall 2025 Shirt',
+        price: 15.00,
+        imgFront: null,
+        imgBack: null
+    },
+    'fall25hoodie' : {
+        name: 'Fall 2025 Hoodie',
+        price: 22.00,
+        imgFront: null,
+        imgBack: null
+    },
+    'fall25both' : {
+        name: 'Fall 2025 Shirt & Hoodie',
+        price: 30.00,
+        imgFront: null,
+        imgBack: null
+    },
     'sp25shirt' : {
         name: 'Spring 2025 Shirt',
         price: 15.00,
@@ -74,6 +94,27 @@ const OrderPage = () => {
 
     if (!product) {
         return <div className='order-page-main'>Item not found</div>;
+    }
+
+    if (apparelId === 'fall25shirt' || apparelId === 'fall25hoodie' || apparelId === 'fall25both') {
+        return(
+            <>
+                <div className='order-page-main'>
+                    <div className='product-name-and-image'>
+                        <h2>{product.name} | ${product.price}</h2>
+                        <figure className="event-figure">
+                            <InstagramPost url="https://www.instagram.com/p/DRQ3FxNDVSh/?igsh=emFjaWJnMTY5ams3" />
+                            <figcaption className="event-caption">Fall 2025 Collection</figcaption>
+                        </figure>
+                    </div>
+                    <div className='gap'></div>
+                    <div className='sizing-and-order'>
+                        Sizing and Payment Option Buttons on right side of page.
+                        Still need to fix sizing and design.
+                    </div>
+                </div>
+            </>
+        );
     }
 
     return(


### PR DESCRIPTION
Introduce Fall 2025 apparel into the shop and wire up ordering UI.

- frontend/src/pages/Shop/sections/Apparel.js: changed the top heading to "Fall 2025", imported InstagramPost and added a Fall 2025 apparel block with an InstagramPost preview and order links (shirt, hoodie, both). Kept Spring 2025 section below.
- frontend/src/pages/Shop/sections/order-pages/OrderPage.js: imported InstagramPost, added apparelData entries for fall25shirt, fall25hoodie, and fall25both (with prices and placeholder images), and added conditional rendering for fall items to show the Instagram preview, product name/price, and a placeholder for sizing/payment controls.
<img width="1710" height="1112" alt="Screenshot 2026-03-21 at 8 33 34 PM" src="https://github.com/user-attachments/assets/104744a1-6e90-44c8-be8b-05e594f2974b" />
<img width="1710" height="1112" alt="Screenshot 2026-03-21 at 8 34 04 PM" src="https://github.com/user-attachments/assets/3cc448e5-4c50-4c0f-bd5a-2d1b4709e8be" />
<img width="1710" height="1112" alt="Screenshot 2026-03-21 at 8 34 14 PM" src="https://github.com/user-attachments/assets/a8be6b08-c324-4169-b7ef-ca00a0b37713" />
<img width="1710" height="1112" alt="Screenshot 2026-03-21 at 8 34 22 PM" src="https://github.com/user-attachments/assets/5ebf6d5c-81bf-4494-ae2e-17922da0a0d7" />
